### PR TITLE
moved react and react-dom to development

### DIFF
--- a/root-config/src/index.ejs
+++ b/root-config/src/index.ejs
@@ -35,8 +35,8 @@
     {
       "imports": {
         "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@5.9.0/lib/system/single-spa.min.js",
-        "react": "https://cdn.jsdelivr.net/npm/react@17.0.2/umd/react.production.min.js",
-        "react-dom": "https://cdn.jsdelivr.net/npm/react-dom@17.0.2/umd/react-dom.production.min.js"
+        "react": "https://cdn.jsdelivr.net/npm/react@17.0.2/umd/react.development.js",
+        "react-dom": "https://cdn.jsdelivr.net/npm/react-dom@17.0.2/umd/react-dom.development.js"
       }
     }
   </script>


### PR DESCRIPTION
i don't think we want to merge this. just an example for what to do when wanting to get HMR running for the root-app.

note, it is recommended to use https://github.com/single-spa/import-map-overrides